### PR TITLE
Fail on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+build-*/
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,13 @@ include(GenerateExportHeader)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
+find_package(Qt5Core REQUIRED)
+
+option(ENABLE_QT "Use QSharedPointer instead of std::shared_ptr (default off)" OFF)
+if (ENABLE_QT)
+    add_compile_definitions(USE_QT)
+endif()
+
 add_library(gen_any_lib SHARED
   genany.cpp
 )
@@ -22,6 +29,7 @@ generate_export_header(
     STATIC_DEFINE
     "GEN_ANY"
 )
+target_link_libraries(gen_any_lib Qt5::Core)
 
 add_executable(pass_any_across_lib
   main.cpp

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,25 @@
+{
+    "version": 2,
+    "configurePresets": [
+        {
+            "name": "dev",
+            "displayName": "dev",
+            "description": "A basic preset for developers",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build-${presetName}",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "dev-qt",
+            "displayName": "Dev with Qt",
+            "cacheVariables": {
+                "ENABLE_QT": true
+            },
+            "inherits": [
+                "dev"
+            ]
+        }
+    ]
+}

--- a/genany.cpp
+++ b/genany.cpp
@@ -1,11 +1,20 @@
 #include "genany.h"
 
-#include <memory>
 #include <iostream>
+
+#if defined(USE_QT)
+#include <QSharedPointer>
+#else
+#include <memory>
+#endif
 
 std::any genAny()
 {
+#if defined(USE_QT)
+    auto ret = std::any(QSharedPointer<int>::create(42));
+#else
     auto ret = std::any(std::make_shared<int>(42));
+#endif
     std::cout << "genAny:\tname=" << ret.type().name() << "\thash_code=" << ret.type().hash_code() << '\n';
     return ret;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1,12 +1,21 @@
 #include <any>
 #include <iostream>
+
+#if defined(USE_QT)
+#include <QSharedPointer>
+#else
 #include <memory>
+#endif
 
 #include "genany.h"
 
 int main()
 {
+#if defined(USE_QT)
+    using WrappedType = QSharedPointer<int>;
+#else
     using WrappedType = std::shared_ptr<int>;
+#endif
 
     auto a = genAny();
     std::cout << "main:\tname=" << a.type().name() << "\thash_code=" << a.type().hash_code() << '\n';


### PR DESCRIPTION
std::bad_any_cast occurs when QSharedPointer is used.